### PR TITLE
Upgrade to SFML 3, fix app bundle, packaging, and README

### DIFF
--- a/BlackEngineProject.app/Contents/Info.plist
+++ b/BlackEngineProject.app/Contents/Info.plist
@@ -5,7 +5,9 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>-bin</string>
+	<string>BlackEngineProject</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>com.blackengine.project</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -18,13 +20,11 @@
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>1.0.0</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.15</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
-	<key>CFBundleIconFile</key>
-	<string></string>
 </dict>
 </plist>

--- a/BlackEngineProject.app/Contents/MacOS/BlackEngineProject
+++ b/BlackEngineProject.app/Contents/MacOS/BlackEngineProject
@@ -10,8 +10,5 @@ MACOS_DIR="${CONTENTS_DIR}/MacOS"
 # Set working directory to Resources so relative asset paths work
 cd "${RES_DIR}" || exit 1
 
-# Prefer bundled OpenAL from app Frameworks
-export DYLD_LIBRARY_PATH="${CONTENTS_DIR}/Frameworks:${DYLD_LIBRARY_PATH}"
-
 # Run the bundled binary
 exec "${MACOS_DIR}/BlackEngineProject-bin"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,13 +34,17 @@ add_executable(BlackEngineProject
   third_party/imgui/imgui_widgets.cpp
 )
 
-# Dependencies (use pkg-config for better compatibility)
+# Dependencies
 find_package(PkgConfig REQUIRED)
 
-# SFML via pkg-config (Homebrew version)
-pkg_check_modules(SFML REQUIRED sfml-system sfml-window sfml-graphics)
-# Try to find audio separately (optional)
-pkg_check_modules(SFML_AUDIO sfml-audio)
+# Vendor SFML 3 (drops OpenAL requirement; uses miniaudio internally)
+include(FetchContent)
+FetchContent_Declare(
+  SFML
+  GIT_REPOSITORY https://github.com/SFML/SFML.git
+  GIT_TAG 3.0.1
+)
+FetchContent_MakeAvailable(SFML)
 
 # Box2D via CMake
 find_package(box2d REQUIRED)
@@ -48,74 +52,45 @@ find_package(box2d REQUIRED)
 # JsonCpp via pkg-config
 pkg_check_modules(JSONCPP REQUIRED jsoncpp)
 
-# ImGui-SFML integration (direct compilation)
+# ImGui include path
 set(IMGUI_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/imgui)
 
 target_include_directories(BlackEngineProject PRIVATE 
   ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${SFML_INCLUDE_DIRS}
   ${JSONCPP_INCLUDE_DIRS}
   ${IMGUI_DIR}
 )
 
 target_link_libraries(BlackEngineProject PRIVATE
-  ${SFML_LIBRARIES}
+  sfml-graphics
+  sfml-window
+  sfml-system
+  sfml-audio
   box2d::box2d
   ${JSONCPP_LIBRARIES}
 )
 
-# Add audio if available
-if(SFML_AUDIO_FOUND)
-  target_link_libraries(BlackEngineProject PRIVATE ${SFML_AUDIO_LIBRARIES})
-  target_compile_definitions(BlackEngineProject PRIVATE SFML_AUDIO_AVAILABLE)
-endif()
+target_compile_definitions(BlackEngineProject PRIVATE SFML_AUDIO_AVAILABLE)
 
-# On macOS, ensure rpath is used so the executable can find Homebrew-installed dylibs
+# On macOS, set rpath and bundle metadata
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-  # Search both next to executable and in app Frameworks
   set_target_properties(BlackEngineProject PROPERTIES
     INSTALL_RPATH "@executable_path;@executable_path/../Frameworks"
   )
 
-  # Bundle metadata
+  # Bundle metadata / Info.plist
   set(BUNDLE_IDENTIFIER "com.blackengine.project")
   set(BUNDLE_ICON_FILE "AppIcon.icns")
   set(BUNDLE_ICON_SOURCE ${CMAKE_SOURCE_DIR}/assets/GUI/AppIcon.icns)
-  # If icon is missing, clear the icon file so Info.plist doesn't reference it
   if(NOT EXISTS ${BUNDLE_ICON_SOURCE})
     set(BUNDLE_ICON_FILE "")
   endif()
 
-  # Configure Info.plist
   configure_file(${CMAKE_SOURCE_DIR}/cmake/Info.plist.in
                  ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/Info.plist
                  @ONLY)
-
-  # Try to locate an OpenAL dylib from common prefixes
-  set(OPENAL_CANDIDATES
-    /usr/local/lib/libopenal.1.dylib
-    /opt/homebrew/lib/libopenal.1.dylib
-  )
-  set(OPENAL_DYLIB "")
-  foreach(p ${OPENAL_CANDIDATES})
-    if(EXISTS ${p})
-      set(OPENAL_DYLIB ${p})
-      break()
-    endif()
-  endforeach()
-
-  # Bundle OpenAL inside the app bundle if found
-  if(OPENAL_DYLIB)
-    add_custom_command(TARGET BlackEngineProject POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E make_directory
-              ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/Frameworks
-      COMMAND ${CMAKE_COMMAND} -E copy_if_different
-              ${OPENAL_DYLIB}
-              ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/Frameworks/libopenal.1.dylib
-    )
-  endif()
 endif()
 
 # Copy assets to build directory for standalone executable
@@ -128,24 +103,20 @@ add_custom_command(TARGET BlackEngineProject POST_BUILD
 # Package into .app bundle: copy binary and assets
 if(APPLE)
   add_custom_command(TARGET BlackEngineProject POST_BUILD
-    # Ensure destination dirs exist
     COMMAND ${CMAKE_COMMAND} -E make_directory
             ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/MacOS
     COMMAND ${CMAKE_COMMAND} -E make_directory
             ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/Resources
 
-    # Copy built binary into the app bundle (as BlackEngineProject-bin to keep script as launcher)
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
             $<TARGET_FILE:BlackEngineProject>
             ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/MacOS/BlackEngineProject-bin
 
-    # Copy assets into app Resources
     COMMAND ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_SOURCE_DIR}/assets
             ${CMAKE_SOURCE_DIR}/BlackEngineProject.app/Contents/Resources/assets
   )
 
-  # Copy icon only if present
   if(EXISTS ${BUNDLE_ICON_SOURCE})
     add_custom_command(TARGET BlackEngineProject POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy_if_different
@@ -167,7 +138,7 @@ add_custom_target(package_app ALL
 )
 add_dependencies(package_app BlackEngineProject)
 
-# Signing and Notarization options
+# Signing / notarization targets
 option(MAC_SIGN "Code sign the app" OFF)
 set(MAC_IDENTITY "" CACHE STRING "Codesign identity (e.g., Developer ID Application: Your Name (TEAMID))")
 set(MAC_TEAM_ID "" CACHE STRING "Apple Developer Team ID")
@@ -178,7 +149,6 @@ set(MAC_BUNDLE_PATH ${CMAKE_SOURCE_DIR}/BlackEngineProject.app)
 set(MAC_ENTITLEMENTS ${CMAKE_SOURCE_DIR}/cmake/Entitlements.plist)
 
 if(APPLE)
-  # Codesign target
   add_custom_target(sign_app
     COMMAND /bin/sh -c "if [ \"${MAC_SIGN}\" = \"ON\" ] && [ -n \"${MAC_IDENTITY}\" ]; then \
       codesign --force --deep --options runtime --entitlements ${MAC_ENTITLEMENTS} --sign \"${MAC_IDENTITY}\" \"${MAC_BUNDLE_PATH}\"; \
@@ -189,7 +159,6 @@ if(APPLE)
     COMMENT "Code signing app bundle"
   )
 
-  # Notarization target (uploads for notarization; requires Xcode tools and credentials)
   add_custom_target(notarize_app
     COMMAND /bin/sh -c "if [ \"${MAC_NOTARIZE}\" = \"ON\" ] && [ -n \"${APPLE_ID}\" ] && [ -n \"${APPLE_ID_PASS}\" ]; then \
       xcrun notarytool submit \"${MAC_BUNDLE_PATH}\" --apple-id \"${APPLE_ID}\" --password \"${APPLE_ID_PASS}\" --team-id \"${MAC_TEAM_ID}\" --wait; \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modern C++ game engine built with SFML, Box2D, and ImGui, featuring an Entity-
 - **Entity-Component System (ECS)**: Flexible and modular game object architecture
 - **2D Physics**: Box2D integration for realistic physics simulation
 - **Graphics**: SFML-based rendering with sprite management
-- **Audio**: SFML audio system (OpenAL bundled inside the macOS app)
+- **Audio**: SFML 3 audio (miniaudio backend, no OpenAL dependency)
 - **Input System**: Keyboard and mouse input handling
 - **Animation System**: JSON-based animation clips with frame-by-frame control
 - **Debug UI**: ImGui integration for real-time debugging and development tools
@@ -56,9 +56,8 @@ Entity
 
 ### Dependencies
 ```bash
-# Install required packages via Homebrew
-brew install sfml box2d jsoncpp
-# (OpenAL is bundled in the .app; no need to install system-wide)
+# Install required packages via Homebrew (SFML 3 is fetched automatically)
+brew install box2d jsoncpp
 ```
 
 ### Building the Project (dev executable)
@@ -83,7 +82,6 @@ make
 - A self-contained `.app` is generated at the project root: `BlackEngineProject.app`
   - Binary at `Contents/MacOS/BlackEngineProject-bin`
   - Assets at `Contents/Resources/assets`
-  - OpenAL at `Contents/Frameworks/libopenal.1.dylib`
 - You can double-click the app in Finder, or run:
 ```bash
 open ./BlackEngineProject.app
@@ -105,13 +103,6 @@ make
 ```
 BlackEngineProject/
 ├── assets/                 # Game assets (copied into build and .app)
-│   ├── animations/         # Animation JSON files
-│   ├── audio/              # Sound effects and music
-│   ├── fonts/              # Font files
-│   ├── GUI/                # UI textures
-│   ├── maps/               # Level data
-│   ├── sprites.png         # Sprite sheet
-│   └── tiles.png           # Tile textures
 ├── include/                # Header files
 ├── src/                    # Source files
 ├── third_party/            # External libraries
@@ -153,11 +144,11 @@ animator.PlayAnimation("walk");
 - **ESC**: Close ImGui debug windows
 
 ## 🔊 Audio
-- Uses SFML audio with OpenAL. The `.app` bundles `libopenal.1.dylib` so end-users do not need Homebrew.
-- In development, audio also works when running the app from Finder or Terminal.
+- SFML 3 audio uses miniaudio internally. No OpenAL or extra dylibs required.
+- Audio works when running from Terminal or Finder.
 
 ## 🧰 Troubleshooting
-- If the app shows missing assets when double-clicked: the app now sets its working directory to `Contents/Resources`; assets are copied there. Rebuild if assets changed.
+- If the app shows missing assets when double-clicked: the app sets its working directory to `Contents/Resources`; rebuild if assets changed.
 - If macOS blocks the app: remove quarantine (`xattr -dr com.apple.quarantine BlackEngineProject.app`).
 
 ## 🔐 Code Signing & Notarization (optional)
@@ -178,7 +169,9 @@ cmake -B cmake-build-debug -S . \
 cmake --build cmake-build-debug --target sign_app
 cmake --build cmake-build-debug --target notarize_app
 ```
-This will sign with hardened runtime and entitlements, submit to Apple Notary Service, and staple the ticket.
+
+## 📚 References
+- SFML 3 repository and docs: [SFML/SFML](https://github.com/SFML/SFML)
 
 ## 📝 License
 This project is open source. See LICENSE file for details.

--- a/cmake/Info.plist.in
+++ b/cmake/Info.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>@PRODUCT_NAME@-bin</string>
+	<string>@PRODUCT_NAME@</string>
 	<key>CFBundleIdentifier</key>
 	<string>@BUNDLE_IDENTIFIER@</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/dist/BlackEngineProject.app/Contents/MacOS/BlackEngineProject
+++ b/dist/BlackEngineProject.app/Contents/MacOS/BlackEngineProject
@@ -10,8 +10,5 @@ MACOS_DIR="${CONTENTS_DIR}/MacOS"
 # Set working directory to Resources so relative asset paths work
 cd "${RES_DIR}" || exit 1
 
-# Prefer bundled OpenAL from app Frameworks
-export DYLD_LIBRARY_PATH="${CONTENTS_DIR}/Frameworks:${DYLD_LIBRARY_PATH}"
-
 # Run the bundled binary
 exec "${MACOS_DIR}/BlackEngineProject-bin"

--- a/include/Components/SpriteComponent.hh
+++ b/include/Components/SpriteComponent.hh
@@ -2,13 +2,14 @@
 #include "Component.hh"
 #include "TransformComponent.hh"
 #include <SFML/Graphics.hpp>
+#include <memory>
 
 class SpriteComponent: public Component
 {
 private:
   TransformComponent* transform;
   sf::Texture texture{};
-  sf::Sprite sprite{};
+  std::unique_ptr<sf::Sprite> sprite; // SFML 3: construct after texture is ready
   const char* textureUrl{};
   unsigned int col{}, row{};
   bool flipTexture{false};

--- a/include/DrawPhysics.hh
+++ b/include/DrawPhysics.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include<box2d/box2d.h>
 #include<SFML/Graphics.hpp>
+#include <cstdint>
 
 class DrawPhysics : public b2Draw
 {
@@ -11,9 +12,9 @@ public:
   ~DrawPhysics();
 
   /// Convert Box2D's OpenGL style color definition[0-1] to SFML's color definition[0-255], with optional alpha byte[Default - opaque]
-	static sf::Color GLColorToSFML(const b2Color &color, sf::Uint8 alpha = 255)
+	static sf::Color GLColorToSFML(const b2Color &color, std::uint8_t alpha = 255)
 	{
-		return sf::Color(static_cast<sf::Uint8>(color.r * 255), static_cast<sf::Uint8>(color.g * 255), static_cast<sf::Uint8>(color.b * 255), alpha);
+		return sf::Color(static_cast<std::uint8_t>(color.r * 255), static_cast<std::uint8_t>(color.g * 255), static_cast<std::uint8_t>(color.b * 255), alpha);
 	}
 
 	/// Convert Box2D's vector to SFML vector [Default - scales the vector up by SCALE constants amount]

--- a/include/GUI/TextObject.hh
+++ b/include/GUI/TextObject.hh
@@ -3,19 +3,21 @@
 
 #include<iostream>
 #include<string>
+#include<cstdint>
+#include<memory>
 
 class TextObject
 {
 private:
-  sf::Font* font{new sf::Font()};
-  sf::Text* text{};
+  sf::Font font{};
+  std::unique_ptr<sf::Text> text{};
   std::string fontUrl;
   int size{};
   sf::Color color;
   std::string textStr{};
 public:
-  TextObject(std::string fontUrl, int size, sf::Color color, sf::Uint32 style);
-  TextObject(std::string fontUrl, int size, sf::Color color, sf::Uint32 style, std::string textStr);
+  TextObject(std::string fontUrl, int size, sf::Color color, std::uint32_t style);
+  TextObject(std::string fontUrl, int size, sf::Color color, std::uint32_t style, std::string textStr);
   ~TextObject();
   void SetTextStr(std::string textStr);
   sf::Text* GetText() const;

--- a/include/Game.hh
+++ b/include/Game.hh
@@ -11,7 +11,6 @@ class Game
 {
 private:
   sf::RenderWindow* window{};
-  sf::Event* event{};
   ContactEventManager* contactEventManager{};
   ImGuiManager* imguiManager{};
   b2Vec2* gravity{};

--- a/include/InputSystem.hh
+++ b/include/InputSystem.hh
@@ -10,19 +10,19 @@ public:
   {
     sf::Vector2f axis{};
 
-    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Right) | sf::Keyboard::isKeyPressed(sf::Keyboard::D))
+    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Right) || sf::Keyboard::isKeyPressed(sf::Keyboard::Key::D))
     {
       axis.x = 1;
     }
-    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Left) | sf::Keyboard::isKeyPressed(sf::Keyboard::A))
+    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Left) || sf::Keyboard::isKeyPressed(sf::Keyboard::Key::A))
     {
       axis.x = -1;
     }
-    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Up) | sf::Keyboard::isKeyPressed(sf::Keyboard::W))
+    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Up) || sf::Keyboard::isKeyPressed(sf::Keyboard::Key::W))
     {
       axis.y = -1;
     }
-    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Down) | sf::Keyboard::isKeyPressed(sf::Keyboard::S))
+    if(sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Down) || sf::Keyboard::isKeyPressed(sf::Keyboard::Key::S))
     {
       axis.y = 1;
     }

--- a/src/AudioClip.cc
+++ b/src/AudioClip.cc
@@ -23,32 +23,18 @@ AudioClip::AudioClip(const char* audioUrl)
   }
   
   try {
-    sound = new sf::Sound();
     buffer = new sf::SoundBuffer();
-    
-    if (!sound) {
-      std::cerr << "Failed to create SFML Sound object" << std::endl;
-      return;
-    }
-    
     if (!buffer) {
       std::cerr << "Failed to create SFML SoundBuffer object" << std::endl;
-      delete sound;
-      sound = nullptr;
       return;
     }
-    
     if (!buffer->loadFromFile(audioUrl)) {
       std::cerr << "Failed to load audio file: " << audioUrl << std::endl;
-      delete sound;
-      delete buffer;
-      sound = nullptr;
-      buffer = nullptr;
+      delete buffer; buffer = nullptr;
       return;
     }
-    
-    sound->setBuffer(*buffer);
-    
+    // Construct sound with buffer (SFML 3)
+    sound = new sf::Sound(*buffer);
   } catch (const std::exception& e) {
     std::cerr << "Exception creating AudioClip: " << e.what() << std::endl;
     if (sound) { delete sound; sound = nullptr; }
@@ -83,10 +69,9 @@ AudioClip::AudioClip(const AudioClip& other)
   buffer = nullptr;
   if (!other.audioUrl.empty()) {
     try {
-      sound = new sf::Sound();
       buffer = new sf::SoundBuffer();
-      if (buffer->loadFromFile(audioUrl)) {
-        sound->setBuffer(*buffer);
+      if (buffer && buffer->loadFromFile(audioUrl)) {
+        sound = new sf::Sound(*buffer);
       }
     } catch (...) {
       if (sound) { delete sound; sound = nullptr; }
@@ -106,10 +91,9 @@ AudioClip& AudioClip::operator=(const AudioClip& other)
   if (buffer) { delete buffer; buffer = nullptr; }
   if (!other.audioUrl.empty()) {
     try {
-      sound = new sf::Sound();
       buffer = new sf::SoundBuffer();
-      if (buffer->loadFromFile(audioUrl)) {
-        sound->setBuffer(*buffer);
+      if (buffer && buffer->loadFromFile(audioUrl)) {
+        sound = new sf::Sound(*buffer);
       }
     } catch (...) {
       if (sound) { delete sound; sound = nullptr; }
@@ -136,8 +120,8 @@ AudioClip& AudioClip::operator=(AudioClip&& other) noexcept
   if (this == &other) return *this;
   audioUrl = std::move(other.audioUrl);
 #ifdef SFML_AUDIO_AVAILABLE
-  if (sound) { delete sound; }
-  if (buffer) { delete buffer; }
+  if (sound) { delete sound; sound = nullptr; }
+  if (buffer) { delete buffer; buffer = nullptr; }
   sound = other.sound; other.sound = nullptr;
   buffer = other.buffer; other.buffer = nullptr;
 #endif

--- a/src/GUI/Button.cc
+++ b/src/GUI/Button.cc
@@ -33,7 +33,7 @@ void Button::Initialize()
   float height{transform.GetHeight()};
 
   rectangleShape = sf::RectangleShape();
-  rectangleShape.setPosition(posX, posY);
+  rectangleShape.setPosition(sf::Vector2f(posX, posY));
   rectangleShape.setSize(sf::Vector2f(width, height));
   rectangleShape.setFillColor(fillColor);
   rectangleShape.setOutlineColor(borderColor);

--- a/src/GUI/TextObject.cc
+++ b/src/GUI/TextObject.cc
@@ -1,57 +1,49 @@
 #include "GUI/TextObject.hh"
 #include <iostream>
 
-TextObject::TextObject(std::string fontUrl, int size, sf::Color color, sf::Uint32 style)
+TextObject::TextObject(std::string fontUrl, int size, sf::Color color, std::uint32_t style)
 {
-  this->fontUrl = fontUrl;
+  this->fontUrl = std::move(fontUrl);
   this->size = size;
   this->color = color;
 
-  if (!font->loadFromFile(fontUrl)) {
-    std::cerr << "Failed to load font: " << fontUrl << std::endl;
+  if (!font.openFromFile(this->fontUrl)) {
+    std::cerr << "Failed to load font: " << this->fontUrl << std::endl;
   }
-  text = new sf::Text();
-  text->setFont(*font);
+  text = std::make_unique<sf::Text>(font);
   text->setCharacterSize(size);
   text->setFillColor(color);
   text->setStyle(style);
 }
 
-TextObject::TextObject(std::string fontUrl, int size, sf::Color color, sf::Uint32 style, std::string textStr)
+TextObject::TextObject(std::string fontUrl, int size, sf::Color color, std::uint32_t style, std::string textStr)
 {
-  this->fontUrl = fontUrl;
+  this->fontUrl = std::move(fontUrl);
   this->size = size;
   this->color = color;
-  this->textStr = textStr;
+  this->textStr = std::move(textStr);
 
-  if (!font->loadFromFile(fontUrl)) {
-    std::cerr << "Failed to load font: " << fontUrl << std::endl;
+  if (!font.openFromFile(this->fontUrl)) {
+    std::cerr << "Failed to load font: " << this->fontUrl << std::endl;
   }
-  text = new sf::Text();
-  text->setFont(*font);
+  text = std::make_unique<sf::Text>(font);
   text->setCharacterSize(size);
   text->setFillColor(color);
   text->setStyle(style);
-  text->setString(textStr);
+  text->setString(this->textStr);
 }
 
 TextObject::~TextObject()
 {
-  if (text) {
-    delete text;
-  }
-  if (font) {
-    delete font;
-  }
 }
 
 void TextObject::SetTextStr(std::string textStr)
 {
-  this->textStr = textStr;
-  text->setString(textStr);
+  this->textStr = std::move(textStr);
+  if (text) text->setString(this->textStr);
 }
 
 sf::Text* TextObject::GetText() const
 {
-  return text;
+  return text.get();
 }

--- a/src/ImGuiManager.cc
+++ b/src/ImGuiManager.cc
@@ -31,43 +31,55 @@ void ImGuiManager::ProcessEvent(const sf::Event& event) {
     if (!m_initialized) return;
     
     ImGuiIO& io = ImGui::GetIO();
-    
-    switch (event.type) {
-        case sf::Event::MouseMoved:
-            io.MousePos.x = static_cast<float>(event.mouseMove.x);
-            io.MousePos.y = static_cast<float>(event.mouseMove.y);
-            break;
-        case sf::Event::MouseButtonPressed:
-            if (event.mouseButton.button == sf::Mouse::Left) io.MouseDown[0] = true;
-            if (event.mouseButton.button == sf::Mouse::Right) io.MouseDown[1] = true;
-            if (event.mouseButton.button == sf::Mouse::Middle) io.MouseDown[2] = true;
-            break;
-        case sf::Event::MouseButtonReleased:
-            if (event.mouseButton.button == sf::Mouse::Left) io.MouseDown[0] = false;
-            if (event.mouseButton.button == sf::Mouse::Right) io.MouseDown[1] = false;
-            if (event.mouseButton.button == sf::Mouse::Middle) io.MouseDown[2] = false;
-            break;
-        case sf::Event::MouseWheelScrolled:
-            io.MouseWheel += event.mouseWheelScroll.delta;
-            break;
-        case sf::Event::KeyPressed:
-            // Handle key input manually for now
-            if (event.key.code == sf::Keyboard::F3) {
+
+    if (event.is<sf::Event::MouseMoved>()) {
+        if (const auto* e = event.getIf<sf::Event::MouseMoved>()) {
+            io.MousePos.x = static_cast<float>(e->position.x);
+            io.MousePos.y = static_cast<float>(e->position.y);
+        }
+        return;
+    }
+    if (event.is<sf::Event::MouseButtonPressed>()) {
+        if (const auto* e = event.getIf<sf::Event::MouseButtonPressed>()) {
+            if (e->button == sf::Mouse::Button::Left) io.MouseDown[0] = true;
+            if (e->button == sf::Mouse::Button::Right) io.MouseDown[1] = true;
+            if (e->button == sf::Mouse::Button::Middle) io.MouseDown[2] = true;
+        }
+        return;
+    }
+    if (event.is<sf::Event::MouseButtonReleased>()) {
+        if (const auto* e = event.getIf<sf::Event::MouseButtonReleased>()) {
+            if (e->button == sf::Mouse::Button::Left) io.MouseDown[0] = false;
+            if (e->button == sf::Mouse::Button::Right) io.MouseDown[1] = false;
+            if (e->button == sf::Mouse::Button::Middle) io.MouseDown[2] = false;
+        }
+        return;
+    }
+    if (event.is<sf::Event::MouseWheelScrolled>()) {
+        if (const auto* e = event.getIf<sf::Event::MouseWheelScrolled>()) {
+            io.MouseWheel += e->delta;
+        }
+        return;
+    }
+    if (event.is<sf::Event::KeyPressed>()) {
+        if (const auto* e = event.getIf<sf::Event::KeyPressed>()) {
+            if (e->code == sf::Keyboard::Key::F3) {
                 m_showTestWindow = !m_showTestWindow;
                 std::cout << "ImGui Test Window: " << (m_showTestWindow ? "ON" : "OFF") << std::endl;
             }
-            if (event.key.code == sf::Keyboard::Escape) {
+            if (e->code == sf::Keyboard::Key::Escape) {
                 m_showTestWindow = false;
                 std::cout << "ImGui Test Window: OFF" << std::endl;
             }
-            break;
-        case sf::Event::KeyReleased:
-            // Handle key input manually for now
-            break;
-        case sf::Event::TextEntered:
-            if (event.text.unicode > 0 && event.text.unicode < 0x10000)
-                io.AddInputCharacter(static_cast<unsigned short>(event.text.unicode));
-            break;
+        }
+        return;
+    }
+    if (event.is<sf::Event::TextEntered>()) {
+        if (const auto* e = event.getIf<sf::Event::TextEntered>()) {
+            if (e->unicode > 0 && e->unicode < 0x10000)
+                io.AddInputCharacter(static_cast<unsigned short>(e->unicode));
+        }
+        return;
     }
 }
 
@@ -179,7 +191,7 @@ void ImGuiManager::ShowDebugInfo() {
 void ImGuiManager::RenderTestIndicator(sf::RenderWindow& window) {
     // Create a simple test indicator using SFML
     sf::RectangleShape testRect(sf::Vector2f(400, 300));
-    testRect.setPosition(50, 50);
+    testRect.setPosition(sf::Vector2f(50, 50));
     testRect.setFillColor(sf::Color(0, 100, 200, 200)); // Semi-transparent blue
     testRect.setOutlineColor(sf::Color::Yellow);
     testRect.setOutlineThickness(3);
@@ -191,18 +203,17 @@ void ImGuiManager::RenderTestIndicator(sf::RenderWindow& window) {
     static bool fontLoaded = false;
     
     if (!fontLoaded) {
-        if (font.loadFromFile("assets/fonts/ARCADECLASSIC.TTF")) {
+        if (font.openFromFile("assets/fonts/ARCADECLASSIC.TTF")) {
             fontLoaded = true;
         }
     }
     
     if (fontLoaded) {
-        sf::Text text;
-        text.setFont(font);
+        sf::Text text(font);
         text.setString("ImGui Test Window Active!\n\nPress F3 to toggle\nPress ESC to close\n\nThis is a test UI indicator\nshowing ImGui integration is working!");
         text.setCharacterSize(18);
         text.setFillColor(sf::Color::White);
-        text.setPosition(70, 70);
+        text.setPosition(sf::Vector2f(70, 70));
         
         window.draw(text);
     }

--- a/src/Tile.cc
+++ b/src/Tile.cc
@@ -17,10 +17,10 @@ float posX, float posY, sf::RenderWindow*& window)
   if (!texture->loadFromFile(textureUrl)) {
     std::cerr << "Failed to load tile texture: " << textureUrl << std::endl;
   }
-  sprite = new sf::Sprite(*texture, sf::IntRect(column * width, row * height, width, height));
-  sprite->setPosition(posX, posY);
+  sprite = new sf::Sprite(*texture, sf::IntRect({column * width, row * height}, {width, height}));
+  sprite->setPosition(sf::Vector2f(posX, posY));
   sprite->setColor(sf::Color::White);
-  sprite->setScale(scale, scale);
+  sprite->setScale(sf::Vector2f(scale, scale));
 }
 
 Tile::~Tile()


### PR DESCRIPTION
This PR upgrades the engine to SFML 3 (via FetchContent), removes OpenAL, adapts code to SFML 3 API (events, rects, vectors, fonts, keyboard), fixes the macOS .app (self-contained, correct executable), adds packaging to dist/, and updates the README.\n\nHighlights:\n- Vendor SFML 3.0.1 [sfml/SFML]\n- Audio via miniaudio (no OpenAL dylib)\n- Finder double-click works; assets bundled in Resources\n- CMake targets: package_app, sign_app, notarize_app\n- README updated: build/run/package/signing steps\n\nPlease review and merge to master.